### PR TITLE
xkbctrl: sort hash keys

### DIFF
--- a/package/yast2-x11.changes
+++ b/package/yast2-x11.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Sep 28 07:30:09 UTC 2018 - bwiedemann@suse.com
+
+- xkbctrl: sort hash keys (boo#1109534)
+- 4.0.1
+
+-------------------------------------------------------------------
 Mon Aug 20 16:17:25 CEST 2018 - schubi@suse.de
 
 - Switched license in spec file from SPDX2 to SPDX3 format.

--- a/package/yast2-x11.spec
+++ b/package/yast2-x11.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-x11
-Version:        4.0.0
+Version:        4.0.1
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/tools/xkbctrl
+++ b/src/tools/xkbctrl
@@ -39,7 +39,7 @@ sub main {
 		$ARGV[0] = $1;
 	}
 	%map = ReadDataConfigMap ($CFGMap);
-	foreach (keys %map) {
+	foreach (sort keys %map) {
 	if ($_ eq $ARGV[0]) {
 		my @list = split (/:/,$map{$_});
 		$XkbLayout   = Tr (shift(@list));
@@ -52,7 +52,7 @@ sub main {
 	$opt{-model}   = $XkbModel;
 	$opt{-variant} = $XkbVariant;
 	$opt{-option}  = $XkbOptions;
-	foreach (keys %opt) {
+	foreach (sort keys %opt) {
 	if (($opt{$_} ne "-") && ($opt{$_} ne "")) {
 		$Apply = "$Apply $_ $opt{$_}";
 	}


### PR DESCRIPTION
in order to generate reproducible output.
This helps the live-langset-data noarch package
to produce identical package build results for i586 and x86_64

Without this patch, it differed thus:
/usr/share/langset/zu_ZA:
 CONSOLE_ENCODING='UTF-8'
-Apply='-option terminate:ctrl_alt_bksp -layout us -model pc105+inet'
+Apply='-model pc105+inet -layout us -option terminate:ctrl_alt_bksp'
 XkbLayout='us'

See https://bugzilla.opensuse.org/show_bug.cgi?id=1109534
and https://reproducible-builds.org/ for why this is matters.