### PR TITLE
Added "active_window" helper tool (jsc#PM-1895, jsc#SLE-16263)

### DIFF
--- a/package/yast2-x11.changes
+++ b/package/yast2-x11.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Fri Feb  5 09:35:45 UTC 2021 - Ladislav Slezák <lslezak@suse.cz>
+
+- Added "active_window" for switching the current X window
+  (or restoring back the previously active window)
+  (jsc#PM-1895, jsc#SLE-16263)
+- 4.3.0
+
+-------------------------------------------------------------------
 Thu Nov 29 15:33:42 UTC 2018 - lslezak@suse.cz
 
 - Explicitly depend on the new yast2-theme, the old yast2_theme

--- a/package/yast2-x11.spec
+++ b/package/yast2-x11.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-x11
-Version:        4.1.0
+Version:        4.3.0
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
@@ -50,6 +50,7 @@ This package contains the programs and files for YaST2 X11 support.
 %files
 %defattr(-,root,root)
 
+%{yast_ybindir}/active_window
 %{yast_ybindir}/testX
 %{yast_ybindir}/set_videomode
 /usr/sbin/xkbctrl

--- a/src/tools/.gitignore
+++ b/src/tools/.gitignore
@@ -1,2 +1,4 @@
 testX.o
 testX
+active_window.o
+active_window

--- a/src/tools/Makefile.am
+++ b/src/tools/Makefile.am
@@ -2,7 +2,7 @@
 # Makefile.am for x11/src/tools
 #
 
-ybin_PROGRAMS = testX
+ybin_PROGRAMS = testX active_window
 
 ybin_SCRIPTS = set_videomode
 
@@ -15,5 +15,11 @@ testX_SOURCES = \
 
 testX_LDFLAGS = \
 	-L/usr/X11R6/lib -L/usr/X11R6/lib64 -lX11 -lXmu
+
+active_window_SOURCES = \
+	active_window.c
+
+active_window_LDFLAGS = \
+	-L/usr/X11R6/lib -L/usr/X11R6/lib64 -lX11
 
 EXTRA_DIST = $(sbin_SCRIPTS) $(man_MANS)

--- a/src/tools/active_window.c
+++ b/src/tools/active_window.c
@@ -1,0 +1,112 @@
+/**
+ * Copyright (c) 2021 SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of version 2 of the GNU General Public License as published
+ * by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ * Extended Window Manager Hints
+ **/
+
+/**
+ * This tool reads or sets the active window. It can be used for restoring back
+ * the currently active window later.
+ *
+ * Usage:
+ *
+ *   active_window [WID]
+ *
+ * Without any parameter it prints the active window ID, with a parameter
+ * it activates the window with that ID [WID].
+ *
+ *
+ * It uses the Extended Window Manager Hints (EWMH) to read and set the active window.
+ * The IceWM used in the installer supports this.
+ *
+ * Resources, links:
+ *
+ * - man pages for XOpenDisplay, XGetWindowProperty and other Xlib calls
+ * - https://specifications.freedesktop.org/wm-spec/wm-spec-latest.html
+ * - https://github.com/leahneukirchen/tools/blob/490cf61021a5d73202f260229d6157d4d11341f3/wmtitle.c
+ * - https://stackoverflow.com/questions/30192347/how-to-restore-a-window-with-xlib
+ * - https://stackoverflow.com/questions/31800880/xlib-difference-between-net-active-window-and-xgetinputfocus
+ * - https://github.com/jordansissel/xdotool/blob/dd45db42f16954f22b445a2c2c928fec202314c4/xdo.c#L686
+ **/
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include <X11/Xlib.h>
+
+int main(int argc, char **argv) {
+    // connect to the X server, NULL = use the $DISPLAY env
+    Display *display = XOpenDisplay(NULL);
+    if (!display) {
+	      return(1);
+    }
+
+    Window root = XDefaultRootWindow(display);
+    // this is the WM property for the currently active window
+    Atom property = XInternAtom(display, "_NET_ACTIVE_WINDOW", False);
+
+    // an argument has been passed, activate the requested window
+    if (argc > 1)
+    {
+        // convert the argument to a window
+        Window window = (Window)strtoul(argv[1], NULL, 0);
+
+        // build an X event, see the links at the top
+        XClientMessageEvent ev;
+        ev.type = ClientMessage;
+        ev.window = window;
+        ev.message_type = property;
+        ev.format = 32;
+        ev.data.l[0] = 1;
+        ev.data.l[1] = CurrentTime;
+        ev.data.l[2] = 0;
+        ev.data.l[3] = 0;
+        ev.data.l[4] = 0;
+
+        // send it to the X server
+        XSendEvent(display, root, False, SubstructureRedirectMask | SubstructureNotifyMask, (XEvent*) &ev);
+        // wait until it is processed
+        XSync(display, False);
+    }
+    // read mode, print the currently active window
+    else
+    {
+        // build the parameters for reading the WM property
+        long offset = 0;
+        long length = ~0;
+        Bool delete = False;
+        Atom req_type = AnyPropertyType;
+        Atom actual_type_return;
+
+        int actual_format_return;
+        unsigned long nitems_return;
+        unsigned long bytes_after_return;
+        unsigned char *prop_return;
+
+        // read the property, see the links at the top
+        if (XGetWindowProperty(display, root, property, offset, length, delete,
+            req_type, &actual_type_return, &actual_format_return,
+            &nitems_return, &bytes_after_return, &prop_return) != Success)
+        {
+            XCloseDisplay(display);
+            return(1);
+        }
+
+        // print the window ID
+        printf("%lu\n", *(unsigned long *) prop_return);
+        XFree(prop_return);
+    }
+
+    XCloseDisplay(display);
+    return 0;
+}

--- a/src/tools/active_window.c
+++ b/src/tools/active_window.c
@@ -22,7 +22,7 @@
  *   active_window [WID]
  *
  * Without any parameter it prints the active window ID, with a parameter
- * it activates the window with that ID [WID].
+ * it activates and raises the window with that ID [WID].
  *
  *
  * It uses the Extended Window Manager Hints (EWMH) to read and set the active window.

--- a/src/tools/active_window.c
+++ b/src/tools/active_window.c
@@ -11,7 +11,6 @@
  * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
  * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
  * more details.
- * Extended Window Manager Hints
  **/
 
 /**


### PR DESCRIPTION
- Related to https://github.com/yast/yast-installation/pull/905
- For the GUI console we need to somehow automatically switch between the console window and the YaST installer window.
- Originally I wanted to use the [xdotool](https://www.semicomplete.com/projects/xdotool/) but that is a generic tool with lots of features and is quite big. It would also add a new dependency. So I wrote a very small single purpose tool.
- Do not ask me for implementation details, I used Google and StackOverflow a lot. :smiley: See the links in the source code.

### Testing

At first just a simple test, get the WID of the active YaST window, then activate it from the xterm:
![active_window_test](https://user-images.githubusercontent.com/907998/107017041-f2be8d00-679e-11eb-91af-7f7699719ce6.gif)

Integration into the YaST console, when the `configure_network` command is finished (the network configuration module is done) then the console (xterm) window is activated and moved to the foreground. Without this tool the user would see "frozen" YaST and need to manually switch via `Alt-Tab`:
![installer_console_gui](https://user-images.githubusercontent.com/907998/106930609-08d43b00-6716-11eb-941a-44e77e7fb297.gif)