### PR TITLE
Added "xftdpi" tool (bsc#1201532)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,12 +6,13 @@ autom4te.cache
 config.cache
 config.guess
 config.h
-config.h.in
+config.h.in*
 config.log
 config.status
 config.sub
 configure
 configure.ac
+compile
 depcomp
 install-sh
 libtool

--- a/package/yast2-x11.changes
+++ b/package/yast2-x11.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Mon Jul 18 14:22:50 UTC 2022 - Ladislav Slezák <lslezak@suse.cz>
+
+- Added "xftdpi" tool to not depend on xrdb (which requires
+  the C pre-processor), this decreases the installed size
+  (bsc#1201532) 
+- 4.5.1
+
+-------------------------------------------------------------------
 Wed Apr 06 13:24:58 UTC 2022 - Ladislav Slezák <lslezak@suse.cz>
 
 - Bump version to 4.5.0 (bsc#1198109)

--- a/package/yast2-x11.spec
+++ b/package/yast2-x11.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-x11
-Version:        4.5.0
+Version:        4.5.1
 Release:        0
 Summary:        YaST2 - X11 support
 License:        GPL-2.0-only
@@ -53,6 +53,7 @@ This package contains the programs and files for YaST2 X11 support.
 %{yast_ybindir}/active_window
 %{yast_ybindir}/testX
 %{yast_ybindir}/set_videomode
+%{yast_ybindir}/xftdpi
 %{_sbindir}/xkbctrl
 %{_sysconfdir}/icewm
 %{_mandir}/man1/xkbctrl.1*

--- a/src/tools/.gitignore
+++ b/src/tools/.gitignore
@@ -1,4 +1,4 @@
-testX.o
-testX
-active_window.o
+*.o
 active_window
+testX
+xftdpi

--- a/src/tools/Makefile.am
+++ b/src/tools/Makefile.am
@@ -2,7 +2,7 @@
 # Makefile.am for x11/src/tools
 #
 
-ybin_PROGRAMS = testX active_window
+ybin_PROGRAMS = testX active_window xftdpi
 
 ybin_SCRIPTS = set_videomode
 
@@ -20,6 +20,12 @@ active_window_SOURCES = \
 	active_window.c
 
 active_window_LDFLAGS = \
+	-L/usr/X11R6/lib -L/usr/X11R6/lib64 -lX11
+
+xftdpi = \
+	xftdpi.c
+
+xftdpi_LDFLAGS = \
 	-L/usr/X11R6/lib -L/usr/X11R6/lib64 -lX11
 
 EXTRA_DIST = $(sbin_SCRIPTS) $(man_MANS)

--- a/src/tools/xftdpi.c
+++ b/src/tools/xftdpi.c
@@ -1,0 +1,139 @@
+/**
+ * Copyright (c) 2022 SUSE LLC
+ *
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of version 2 of the GNU General Public License as published
+ * by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ **/
+
+/**
+ * This tool reads and sets the "Xft.dpi" X resource property.
+ *
+ * Alternatively we could use the "xrdb" tool but unfortunately it depends on the
+ * C pre-processor (~22MB!) and increases size of the installed system a lot.
+ *
+ * Usage:
+ *
+ *   xftdpi [DPI]
+ *
+ * Without any parameter it prints the current setting (and also the size of the
+ * default screen), with a parameter it sets that DPI resolution.
+ *
+ *
+ * This tool uses a simplified implementation because it is supposed to be
+ * called only by the YaST starting script, it:
+ *
+ * - does not validate the argument, make sure it is an integer number with
+ *   a reasonable value
+ *   (YaST sets a value in a predefined range, ignoring too high or too low values)
+ *
+ * - does not merge the X resources, it simply appends the option at the end
+ *   regardless it is already present or not, calling it several times results
+ *   in multiple setting present
+ *   (it should be called just once by the YaST starting script, there are
+ *    no resources defined in the inst-sys and the last setting wins anyway,
+ *    see "man XrmGetDatabase")
+ *
+ * - does not check the maximum size of the X request, we set just a single short
+ *   value (too long string would need to be split into several calls)
+ *
+ * Resources, links:
+ *
+ * - man pages for XOpenDisplay, XrmGetDatabase, XResourceManagerString, ...
+ *   and other Xlib calls
+ * - xrdb sources (https://gitlab.freedesktop.org/xorg/app/xrdb/-/blob/master/xrdb.c)
+ **/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <X11/Xlib.h>
+#include <X11/Xresource.h>
+#include <X11/Xatom.h>
+
+// compute DPI resolution from pixels and milimeters
+int resolution(int width_px, int width_mm);
+int resolution(int width_px, int width_mm)
+{
+  // avoid division by zero
+  if (width_mm == 0)
+    return 0;
+  else
+    return (double)(width_px) / ((double)(width_mm) / 25.4);
+}
+
+int main(int argc, char **argv)
+{
+  // connect to the X server, NULL = use the $DISPLAY env
+  Display *display = XOpenDisplay(NULL);
+  if (!display)
+  {
+    return 1;
+  }
+
+  // an argument has been passed, set the "Xft.dpi" resource
+  if (argc > 1)
+  {
+    // append "Xfti.dpi: " with the command line argument to the X resources
+    const char *xft = "Xft.dpi: ";
+    // allocate buffer for the new string, 2 = newline separator + NULL terminator
+    char *new_data = malloc(strlen(xft) + strlen(argv[1]) + 2);
+    char *ptr = new_data;
+
+    // the existing resources might miss the trailing new line, add it just to be sure
+    // (if it already is there then it does not harm, an empty line is allowed)
+    ptr[0] = '\n';
+    ptr = ptr + 1;
+
+    // append "Xft.dpi: "
+    strcpy(ptr, xft);
+    ptr = ptr + strlen(xft);
+
+    // append the command line argument
+    strcpy(ptr, argv[1]);
+
+    // append the the data to the X server resource property
+    XChangeProperty(display, XDefaultRootWindow(display), XA_RESOURCE_MANAGER,
+                    // 8 = the data is 8 bits per item (8, 16 and 32 are possible)
+                    XA_STRING, 8, PropModeAppend, (unsigned char *)new_data, strlen(new_data));
+
+    free(new_data);
+  }
+  else
+  // no command line argument, just dump the current configuration
+  {
+    Screen *screen = ScreenOfDisplay(display, DefaultScreen(display));
+    printf("Width: %d px, %d mm, %d dpi\n", screen->width, screen->mwidth,
+           resolution(screen->width, screen->mwidth));
+    printf("Height: %d px, %d mm, %d dpi\n", screen->height, screen->mheight,
+           resolution(screen->height, screen->mheight));
+
+    // initialize database
+    XrmInitialize();
+    XGetDefault(display, "", "");
+
+    XrmDatabase xrdb = XrmGetDatabase(display);
+    char *type = NULL;
+    XrmValue value;
+
+    // search for the "Xft.dpi" value
+    Bool found = XrmGetResource(xrdb, "Xft.dpi", "Xft.Dpi", &type, &value);
+
+    printf("Xft.dpi: ");
+    if (found == True && value.addr != NULL)
+      printf("%s dpi\n", value.addr);
+    else
+      printf("not defined\n");
+  }
+
+  XCloseDisplay(display);
+  return 0;
+}


### PR DESCRIPTION
## Problem

- https://bugzilla.suse.com/show_bug.cgi?id=1201532
- YaST depends on the `xrdb` tool to set the `Xft.dpi` X resource property ([code](https://github.com/yast/yast-installation/blob/241aaba4ae1777f95839adaccf3cc835804f19c2/startup/YaST2.call#L95), [dependency](https://github.com/yast/yast-installation/blob/effedf2b8134581b631ffbf67a98af095127b232/package/yast2-installation.spec#L73))
- Unfortunately `xrdb` tool depends on the pre-processor (~22MB!) and that increases the installed size a lot, esp. in a minimal graphical installation
  - When building the inst-sys we explicitly ignore all `xrdb` dependencies so it is not there, but we cannot do that for the installed system

## Solution

- Extract the `xrdb` functionality into a separate tool, what we need is just to set one integer value

## Notes

- The implementation is simplified as the tool is expected to be called just from the YaST starting scripts in the inst-sys. See the comments in the code.
- This will be used from `yast2-installation` (separate pull request will be created)

## Testing

- Tested manually

