### PR TITLE
use also kbd-model-map.xkb-generated (bsc#1211104)

### DIFF
--- a/package/yast2-x11.changes
+++ b/package/yast2-x11.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Oct 10 11:09:32 UTC 2023 - Martin Vidner <mvidner@suse.com>
+
+- xkbctrl: use also kbd-model-map.xkb-generated (bsc#1211104)
+- 5.0.1
+
+-------------------------------------------------------------------
 Wed Aug 30 20:16:10 UTC 2023 - Josef Reidinger <jreidinger@suse.cz>
 
 - 5.0.0 (#bsc1185510)

--- a/package/yast2-x11.spec
+++ b/package/yast2-x11.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-x11
-Version:        5.0.0
+Version:        5.0.1
 Release:        0
 Summary:        YaST2 - X11 support
 License:        GPL-2.0-only

--- a/src/tools/xkbctrl
+++ b/src/tools/xkbctrl
@@ -14,6 +14,7 @@ use strict;
 # Globals...
 #---------------------------------
 my $CFGMap = "/usr/share/systemd/kbd-model-map";
+my $CFGMap2 = "/usr/share/systemd/kbd-model-map.xkb-generated";
 
 #=================================
 # The magic main :-)
@@ -30,6 +31,7 @@ sub main {
 	my $Apply;
 
 	my %map;
+	my %map2;
 	my %opt;
 
 	if (! defined $ARGV[0]) {
@@ -39,6 +41,9 @@ sub main {
 		$ARGV[0] = $1;
 	}
 	%map = ReadDataConfigMap ($CFGMap);
+	%map2 = ReadDataConfigMap ($CFGMap2);
+	%map = (%map, %map2);
+
 	foreach (sort keys %map) {
 	if ($_ eq $ARGV[0]) {
 		my @list = split (/:/,$map{$_});


### PR DESCRIPTION
## Problem

Same problem as in https://github.com/yast/yast-country/pull/315
where `yast keyboard` then calls `xkbctrl` from this package.

- [bsc#1211104](https://bugzilla.suse.com/show_bug.cgi?id=1211104)

## Solution

- read both `kbd-model-map` and `kbd-model-map.xkb-generated` here


## Testing

- Tested manually


## Screenshots

N/A
