### PR TITLE
Improved Child Process Handling [SLE-15-SP5]

### DIFF
--- a/package/yast2-x11.changes
+++ b/package/yast2-x11.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Oct 23 09:22:36 UTC 2023 - Stefan Hundhammer <shundhammer@suse.com>
+
+- Prevent testX from hanging in second stage if no supported WM
+  can be started (bsc#1216297)
+- 4.5.2
+
+-------------------------------------------------------------------
 Mon Jul 18 14:22:50 UTC 2022 - Ladislav Slezák <lslezak@suse.cz>
 
 - Added "xftdpi" tool to not depend on xrdb (which requires

--- a/package/yast2-x11.spec
+++ b/package/yast2-x11.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-x11
-Version:        4.5.1
+Version:        4.5.2
 Release:        0
 Summary:        YaST2 - X11 support
 License:        GPL-2.0-only

--- a/src/tools/testX.c
+++ b/src/tools/testX.c
@@ -161,7 +161,7 @@ XColor NameToXColor(Display* dpy, const char* name, unsigned long pixel)
     }
     else if (!XParseColor(dpy, DefaultColormap(dpy, screen), name, &c))
     {
-	fprintf(stderr, "testX: unknown color or bad color format: %s\n", name);
+	fprintf(stderr, "\ntestX: unknown color or bad color format: %s\n", name);
 	exit(1);
     }
 
@@ -177,7 +177,7 @@ void RunWindowManager(void)
     {
 	case -1:
             // fork() failed
-	    fprintf(stderr, "testX: FATAL: fork() failed\n");
+	    fprintf(stderr, "\ntestX: FATAL: fork() failed\n");
             exit(2);
 
 	case 0:
@@ -191,7 +191,7 @@ void RunWindowManager(void)
 	    execlp(TWM, "twm", NULL);
 
             // exec..() only returns if the process could not be started.
-	    fprintf(stderr, "testX: Could not run any windowmanager\n");
+	    fprintf(stderr, "\ntestX: Could not run any windowmanager\n");
 
             // Exit, don't return. We don't want to return to main() in the
             // child process to do more X11 calls with the parent process's X
@@ -201,7 +201,7 @@ void RunWindowManager(void)
 	default:
             // Parent process
 
-            // fprintf(stderr, "testX: Started child process %d to start a window manager\n", wm_pid);
+            // fprintf(stderr, "\ntestX: Started child process %d to start a window manager\n", wm_pid);
             break;
     }
 }
@@ -214,6 +214,6 @@ void SigChildHandler(int sig_num)
 
     if (pid != 0 && exit_status > 0)
     {
-        fprintf(stderr, "testX: Child process %d exited with %d\n", pid, exit_status);
+        fprintf(stderr, "\ntestX: Child process %d exited with %d\n", pid, exit_status);
     }
 }

--- a/src/tools/testX.c
+++ b/src/tools/testX.c
@@ -41,7 +41,6 @@
 #define FVWMRC     "fvwmrc.yast2"
 
 int screen;
-int wm_pid = -1;
 
 Cursor CreateCursorFromName(Display* dpy, const char* name);
 XColor NameToXColor(Display* dpy, const char* name, unsigned long pixel);

--- a/src/tools/testX.c
+++ b/src/tools/testX.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2012 Novell, Inc.
+ * Copyright (c) 2023 SUSE Linux LLC
  *
  * All Rights Reserved.
  *
@@ -19,23 +20,6 @@
  * find current contact information at www.novell.com.
  */
 
-/**************
-FILE          : testX.c
-***************
-PROJECT       : SaX ( SuSE advanced X configuration )
-              :
-BELONGS TO    : Configuration tool X11 version 4.x
-              : YaST2 inst-sys tools
-              :
-DESCRIPTION   : Checks if the X server is ok and sets the root
-              : window's color. Forks a child that creates an
-              : invisible X client. The child exits when the
-              : X server exits.
-              :
-              : Exit code: 0: X server ok, 1: no X server.
-              :
-STATUS        : Status: Up-to-date
-**************/
 
 #include <stdio.h>
 #include <unistd.h>
@@ -47,9 +31,6 @@ STATUS        : Status: Up-to-date
 #include <sys/types.h>
 #include <sys/wait.h>
 
-//======================================
-// Defines
-//--------------------------------------
 #define ICEWM     "icewm"
 #define FVWM      "fvwm2"
 #define MWM       "mwm"
@@ -58,14 +39,8 @@ STATUS        : Status: Up-to-date
 #define ICEWMPREFS "preferences.yast2"
 #define FVWMRC     "fvwmrc.yast2"
 
-//======================================
-// Globals
-//--------------------------------------
 int screen;
 
-//======================================
-// Functions
-//--------------------------------------
 Cursor CreateCursorFromName(Display* dpy, const char* name);
 XColor NameToXColor(Display* dpy, const char* name, unsigned long pixel);
 int RunWindowManager(void);
@@ -79,16 +54,20 @@ int main(int argc, char** argv)
     char* cname;
     XColor color;
     Atom prop;
-    Pixmap save_pixmap = (Pixmap)None;
+    Pixmap save_pixmap = (Pixmap) None;
 
     //============================================
     // open display and check if we got a display
     //--------------------------------------------
     display = XOpenDisplay(NULL);
-    if (!display) {
+
+    if (!display)
+    {
 	exit (1);
     }
-    if ((argc == 2) && (strcmp(argv[1], "--fast") == 0)) {
+
+    if ((argc == 2) && (strcmp(argv[1], "--fast") == 0))
+    {
 	XCloseDisplay(display);
 	exit (0);
     }
@@ -101,8 +80,10 @@ int main(int argc, char** argv)
     root = RootWindow(display, screen);
     pixel = BlackPixel(display, screen);
 
-    if (XParseColor(display, DefaultColormap(display, screen), cname, &color)) {
-	if (XAllocColor(display, DefaultColormap(display, screen), &color)) {
+    if (XParseColor(display, DefaultColormap(display, screen), cname, &color))
+    {
+	if (XAllocColor(display, DefaultColormap(display, screen), &color))
+        {
 	    pixel = color.pixel;
 	}
     }
@@ -110,16 +91,17 @@ int main(int argc, char** argv)
     XClearWindow(display, root);
 
     //============================================
-    // set watch cursor
+    // set the cursor
     //--------------------------------------------
     cursor = CreateCursorFromName(display, "top_left_arrow");
-    if (cursor) {
+    if (cursor)
+    {
 	XDefineCursor(display, root, cursor);
 	XFreeCursor(display, cursor);
     }
 
     //============================================
-    // run the windowmanager (FVWM)
+    // start a window manager
     //--------------------------------------------
     RunWindowManager();
 
@@ -133,15 +115,13 @@ int main(int argc, char** argv)
     XSetCloseDownMode(display, RetainPermanent);
 
     //============================================
-    // close display and exit
+    // Shut down
     //--------------------------------------------
     XCloseDisplay(display);
-    exit (0);
+    exit(0);
 }
 
-//=========================================
-// CreateCursorFromName
-//-----------------------------------------
+
 Cursor CreateCursorFromName(Display* dpy, const char* name)
 {
     XColor fg, bg;
@@ -154,34 +134,35 @@ Cursor CreateCursorFromName(Display* dpy, const char* name)
     bg = NameToXColor(dpy, back_color, WhitePixel(dpy, screen));
 
     i = XmuCursorNameToIndex(name);
+
     if (i == -1)
 	return (Cursor) 0;
     fid = XLoadFont (dpy, "cursor");
     if (!fid)
 	return (Cursor) 0;
+
     return XCreateGlyphCursor(dpy, fid, fid, i, i+1, &fg, &bg);
 }
 
-//=========================================
-// NameToXColor
-//-----------------------------------------
+
 XColor NameToXColor(Display* dpy, const char* name, unsigned long pixel)
 {
     XColor c;
 
-    if (!name || !*name) {
+    if (!name || !*name)
+    {
 	c.pixel = pixel;
 	XQueryColor(dpy, DefaultColormap(dpy, screen), &c);
-    } else if (!XParseColor(dpy, DefaultColormap(dpy, screen), name, &c)) {
+    }
+    else if (!XParseColor(dpy, DefaultColormap(dpy, screen), name, &c))
+    {
 	fprintf(stderr, "testX: unknown color or bad color format: %s\n", name);
 	exit(1);
     }
+
     return c;
 }
 
-//=========================================
-// RunWindowManager
-//-----------------------------------------
 int RunWindowManager(void)
 {
     int wmpid = fork();


### PR DESCRIPTION
## Target Branch

**_This is for SLE-15-SP5._** A merge to _SLE-15-SP6_ and to _master_ (Factory / TW) will follow.

## Bugzilla

https://bugzilla.suse.com/show_bug.cgi?id=1216197


## Problem

In some cases, `testX` hangs during the second stage of an installation.


## Cause

If none of the window managers that are tried is available, the child process still returns to the main program and then happily continues execution there - and it executes X11 calls with the X connection that it inherited from its parent process. From that point on, anything can happen; for example, X protocol errors because the child process may interrupt the parent process while sending X packets. Or one process may hang because it waits for an X response that may already have been consumed by the other process.

This has been broken for many years, but the problem was probably hidden because one of those window managers was always available.


## Fix

The child process needs to exit (with an error code) if it could not `exec()` a window manager. Whatever it does, it may never return to `main()` and mess up the parent process's X connection.


## Other Improvements

Child process handling was very much broken: In the parent process, it tried to call `waitpid()` immediately, but with `WNOHANG`, i.e. without any delay. Of course that always returned 0 (no process had exited yet), because even in the best case the child process wasn't ready yet: It tries several window managers, and if none of them could be started with `exec()`, it exits. But that takes some CPU cycles; more than the parent process which had nothing else to do but `waitpid()`.

Now it uses a signal handler for `SIGCHLD` and does `waitpid()` there.


## Related PRs

- Merge to SLE-15-SP6: _TBD_
- Merge to master / Factory / TW: _TBD_