### PR TITLE
Improved Child Process Handling [SLE-15-SP6]

### DIFF
--- a/package/yast2-x11.changes
+++ b/package/yast2-x11.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Oct 23 09:22:36 UTC 2023 - Stefan Hundhammer <shundhammer@suse.com>
+
+- Prevent testX from hanging in second stage if no supported WM
+  can be started (bsc#1216297)
+- 4.6.2
+
+-------------------------------------------------------------------
 Tue Oct 17 14:43:21 UTC 2023 - Martin Vidner <mvidner@suse.com>
 
 - xkbctrl: use also kbd-model-map.xkb-generated (bsc#1211104)

--- a/package/yast2-x11.spec
+++ b/package/yast2-x11.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-x11
-Version:        4.6.1
+Version:        4.6.2
 Release:        0
 Summary:        YaST2 - X11 support
 License:        GPL-2.0-only


### PR DESCRIPTION
## Target Branch

**_This is the merge to SLE-15-SP6_** of PR #29 .

## Bugzilla

https://bugzilla.suse.com/show_bug.cgi?id=1216197


## Problem

In some cases, `testX` hangs during the second stage of an installation.


## Cause

If none of the window managers that are tried is available, the child process still returns to the main program and then happily continues execution there - and it executes X11 calls with the X connection that it inherited from its parent process. From that point on, anything can happen; for example, X protocol errors because the child process may interrupt the parent process while sending X packets. Or one process may hang because it waits for an X response that may already have been consumed by the other process.

This has been broken for many years, but the problem was probably hidden because one of those window managers was always available.


## Fix

The child process needs to exit (with an error code) if it could not `exec()` a window manager. Whatever it does, it may never return to `main()` and mess up the parent process's X connection.


## Other Improvements

Child process handling was very much broken: In the parent process, it tried to call `waitpid()` immediately, but with `WNOHANG`, i.e. without any delay. Of course that always returned 0 (no process had exited yet), because even in the best case the child process wasn't ready yet: It tries several window managers, and if none of them could be started with `exec()`, it exits. But that takes some CPU cycles; more than the parent process which had nothing else to do but `waitpid()`.

Now it uses a signal handler for `SIGCHLD` and does `waitpid()` there.


## Related PRs

- Original PR for SLE-15-SP5: #29 
- Merge to master / Factory / TW: _TBD_