### PR TITLE
Improved Child Process Handling [master]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
   Package:
     runs-on: ubuntu-latest
     container:
-      image: registry.opensuse.org/yast/sle-15/sp4/containers/yast-cpp:latest
+      image: registry.opensuse.org/yast/head/containers/yast-cpp:latest
 
     steps:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
   Package:
     runs-on: ubuntu-latest
     container:
-      image: registry.opensuse.org/yast/sle-15/sp5/containers/yast-cpp:latest
+      image: registry.opensuse.org/yast/sle-15/sp6/containers/yast-cpp:latest
 
     steps:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,6 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: registry.opensuse.org/yast/head/containers/yast-cpp:latest
-      options: --privileged
 
     steps:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,9 @@ on: [push, pull_request]
 jobs:
   Package:
     runs-on: ubuntu-latest
-    container: registry.opensuse.org/yast/head/containers/yast-cpp:latest
+    container:
+      image: registry.opensuse.org/yast/head/containers/yast-cpp:latest
+      options: --privileged
 
     steps:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
   Package:
     runs-on: ubuntu-latest
     container:
-      image: registry.opensuse.org/yast/head/containers/yast-cpp:latest
+      image: registry.opensuse.org/yast/sle-15/sp5/containers/yast-cpp:latest
 
     steps:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
   Package:
     runs-on: ubuntu-latest
     container:
-      image: registry.opensuse.org/yast/head/containers/yast-cpp:latest
+      image: registry.opensuse.org/yast/sle-15/sp4/containers/yast-cpp:latest
 
     steps:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
   Package:
     runs-on: ubuntu-latest
     container:
-      image: registry.opensuse.org/yast/sle-15/sp6/containers/yast-cpp:latest
+      image: registry.opensuse.org/yast/head/containers/yast-cpp:latest
 
     steps:
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,6 @@
 require "yast/rake"
 
-Yast::Tasks.submit_to :sle15sp5
+Yast::Tasks.submit_to :sle15sp6
 
 Yast::Tasks.configuration do |conf|
   #lets ignore license check for now

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,7 @@
 require "yast/rake"
 
+Yast::Tasks.submit_to :sle15sp4
+
 Yast::Tasks.configuration do |conf|
   #lets ignore license check for now
   conf.skip_license_check << /.*/

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,7 @@
 require "yast/rake"
 
+Yast::Tasks.submit_to :sle15sp5
+
 Yast::Tasks.configuration do |conf|
   #lets ignore license check for now
   conf.skip_license_check << /.*/

--- a/Rakefile
+++ b/Rakefile
@@ -1,7 +1,5 @@
 require "yast/rake"
 
-Yast::Tasks.submit_to :sle15sp4
-
 Yast::Tasks.configuration do |conf|
   #lets ignore license check for now
   conf.skip_license_check << /.*/

--- a/Rakefile
+++ b/Rakefile
@@ -1,7 +1,5 @@
 require "yast/rake"
 
-Yast::Tasks.submit_to :sle15sp6
-
 Yast::Tasks.configuration do |conf|
   #lets ignore license check for now
   conf.skip_license_check << /.*/

--- a/package/yast2-x11.changes
+++ b/package/yast2-x11.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Wed Apr 06 13:24:58 UTC 2022 - Ladislav Slezák <lslezak@suse.cz>
+
+- Bump version to 4.5.0 (#bsc1198109)
+
+-------------------------------------------------------------------
 Tue Apr 20 18:14:05 UTC 2021 - Dirk Müller <dmueller@suse.com>
 
 - stop packaging docdir, it only contained the license which

--- a/package/yast2-x11.changes
+++ b/package/yast2-x11.changes
@@ -1,7 +1,7 @@
 -------------------------------------------------------------------
 Wed Apr 06 13:24:58 UTC 2022 - Ladislav Slezák <lslezak@suse.cz>
 
-- Bump version to 4.5.0 (#bsc1198109)
+- Bump version to 4.5.0 (bsc#1198109)
 
 -------------------------------------------------------------------
 Tue Apr 20 18:14:05 UTC 2021 - Dirk Müller <dmueller@suse.com>

--- a/package/yast2-x11.changes
+++ b/package/yast2-x11.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Tue Apr 20 13:51:55 UTC 2021 - Ladislav Slezák <lslezak@suse.cz>
+
+- 4.4.0
+
+-------------------------------------------------------------------
 Fri Feb  5 09:35:45 UTC 2021 - Ladislav Slezák <lslezak@suse.cz>
 
 - Added "active_window" for switching the current X window

--- a/package/yast2-x11.changes
+++ b/package/yast2-x11.changes
@@ -3,18 +3,18 @@ Mon Oct 23 09:22:36 UTC 2023 - Stefan Hundhammer <shundhammer@suse.com>
 
 - Prevent testX from hanging in second stage if no supported WM
   can be started (bsc#1216297)
-- 4.6.2
+- 5.0.2
 
 -------------------------------------------------------------------
-Tue Oct 17 14:43:21 UTC 2023 - Martin Vidner <mvidner@suse.com>
+Tue Oct 10 11:09:32 UTC 2023 - Martin Vidner <mvidner@suse.com>
 
 - xkbctrl: use also kbd-model-map.xkb-generated (bsc#1211104)
-- 4.6.1
+- 5.0.1
 
 -------------------------------------------------------------------
-Fri Sep 01 19:57:03 UTC 2023 - Josef Reidinger <jreidinger@suse.com>
+Wed Aug 30 20:16:10 UTC 2023 - Josef Reidinger <jreidinger@suse.cz>
 
-- Branch package for SP6 (bsc#1208913)
+- 5.0.0 (#bsc1185510)
 
 -------------------------------------------------------------------
 Fri Mar 03 14:44:07 UTC 2023 - Ladislav Slezák <lslezak@suse.cz>

--- a/package/yast2-x11.changes
+++ b/package/yast2-x11.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Fri Sep 01 19:57:03 UTC 2023 - Josef Reidinger <jreidinger@suse.com>
+
+- Branch package for SP6 (bsc#1208913)
+
+-------------------------------------------------------------------
 Mon Jul 18 14:22:50 UTC 2022 - Ladislav Slezák <lslezak@suse.cz>
 
 - Added "xftdpi" tool to not depend on xrdb (which requires

--- a/package/yast2-x11.spec
+++ b/package/yast2-x11.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-x11
-Version:        4.5.1
+Version:        4.6.0
 Release:        0
 Summary:        YaST2 - X11 support
 License:        GPL-2.0-only

--- a/package/yast2-x11.spec
+++ b/package/yast2-x11.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-x11
-Version:        4.6.2
+Version:        5.0.2
 Release:        0
 Summary:        YaST2 - X11 support
 License:        GPL-2.0-only

--- a/package/yast2-x11.spec
+++ b/package/yast2-x11.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-x11
-Version:        4.3.0
+Version:        4.4.0
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/package/yast2-x11.spec
+++ b/package/yast2-x11.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-x11
-Version:        4.4.1
+Version:        4.5.0
 Release:        0
 Summary:        YaST2 - X11 support
 License:        GPL-2.0-only


### PR DESCRIPTION
## Target Branch

**_This is the merge to master_** of PR #31 / PR  #29.

## Bugzilla

https://bugzilla.suse.com/show_bug.cgi?id=1216197


## Problem

In some cases, `testX` hangs during the second stage of an installation.


## Cause

If none of the window managers that are tried is available, the child process still returns to the main program and then happily continues execution there - and it executes X11 calls with the X connection that it inherited from its parent process. From that point on, anything can happen; for example, X protocol errors because the child process may interrupt the parent process while sending X packets. Or one process may hang because it waits for an X response that may already have been consumed by the other process.

This has been broken for many years, but the problem was probably hidden because one of those window managers was always available.


## Fix

The child process needs to exit (with an error code) if it could not `exec()` a window manager. Whatever it does, it may never return to `main()` and mess up the parent process's X connection.


## Other Improvements

Child process handling was very much broken: In the parent process, it tried to call `waitpid()` immediately, but with `WNOHANG`, i.e. without any delay. Of course that always returned 0 (no process had exited yet), because even in the best case the child process wasn't ready yet: It tries several window managers, and if none of them could be started with `exec()`, it exits. But that takes some CPU cycles; more than the parent process which had nothing else to do but `waitpid()`.

Now it uses a signal handler for `SIGCHLD` and does `waitpid()` there.


## Related PRs

- Original PR for SLE-15-SP5: #29 
- Merge to SLE-15-SP6: #31 